### PR TITLE
Fix header usage

### DIFF
--- a/job_search.py
+++ b/job_search.py
@@ -167,11 +167,6 @@ def title_is_allowed(title: str, threshold: float = 0.7) -> bool:
     )
     return best >= threshold
 
-# Separate headers for Relocate.me requests so that other scrapers keep
-# the more realistic browser headers defined above.
-RELOCATE_HEADERS = {
-    "User-Agent": "Mozilla/5.0 (reloc8-agent test)"
-}
 
 KEYWORDS = [
     "product-manager",
@@ -189,7 +184,7 @@ BASE = ROOT + "/international-jobs/{}"
 
 def scrape_page(slug: str):
     url = BASE.format(slug)
-    r = requests.get(url, headers=RELOCATE_HEADERS, timeout=30)
+    r = requests.get(url, headers=HEADERS, timeout=30)
     r.raise_for_status()
 
     soup = BeautifulSoup(r.text, "html.parser")

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,9 @@
+import unittest
+
+class ImportTests(unittest.TestCase):
+    def test_import_job_search(self):
+        import job_search  # noqa: F401
+        self.assertTrue(hasattr(job_search, "HEADERS"))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove redundant header dictionary from job_search
- call all requests with the original `HEADERS`
- add a simple import test

## Testing
- `python -m pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python -m unittest discover -v -s tests` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68453242e8808325b3500089226fc0c1