### PR TITLE
Fix job filtering and Telegram flow

### DIFF
--- a/bot_notify.py
+++ b/bot_notify.py
@@ -11,6 +11,17 @@ def send_message(text):
     resp = requests.post(url, json={"chat_id": CHAT_ID, "text": text})
     resp.raise_for_status()
 
+def send_document(path, caption=None):
+    """Upload a document to the chat."""
+    url = f"{API_URL}/sendDocument"
+    with open(path, "rb") as f:
+        resp = requests.post(
+            url,
+            data={"chat_id": CHAT_ID, "caption": caption or ""},
+            files={"document": f},
+        )
+    resp.raise_for_status()
+
 def await_reply(timeout_sec=1800):
     """Polls for a reply that contains numbers like 1 3 4"""
     url = f"{API_URL}/getUpdates"

--- a/job_search.py
+++ b/job_search.py
@@ -131,12 +131,6 @@ ALLOW_TITLES = [
     "product manager ai",
     "ai product manager",
     "principal product manager",
-    "product design lecturer",
-    "product design professor",
-    "industrial design lecturer",
-    "industrial design professor",
-    "product management lecturer",
-    "product management professor",
 ]
 
 BLOCK_KEYWORDS = [
@@ -174,8 +168,6 @@ KEYWORDS = [
     "staff-product-manager",
     "principal-product-manager",
     "innovation-manager",
-    "design-lecturer",
-    "design-school-lecturer",
 ]
 
 ROOT = "https://relocate.me"
@@ -215,14 +207,14 @@ def scrape_page(slug: str):
     return rows
 
 def _keep(job, seen_set):
-    if job["link"] in seen_set:
+    canonical = job["link"].split("?", 1)[0]
+    if canonical in seen_set:
         return False
-    # Keep the job only if at least one of the following is true:
-    #   1) Title passes your fuzzy allow-list
-    #   2) The detail page explicitly mentions relocation/visa
-    if not (title_is_allowed(job["title"]) or page_mentions_relocation(job["link"])):
+    if not title_is_allowed(job["title"]):
         return False
-    seen_set.add(job["link"])
+    if not page_mentions_relocation(job["link"]):
+        return False
+    seen_set.add(canonical)
     return True
 
 def search_jobs():

--- a/tests/test_job_search.py
+++ b/tests/test_job_search.py
@@ -31,7 +31,7 @@ def test_skip_seen_job(monkeypatch):
 def test_allowed_title_passes(monkeypatch):
     job = {"link": "http://example.com/job2", "title": "Product Manager"}
     seen = set()
-    monkeypatch.setattr(job_search, "page_mentions_relocation", lambda url: False)
+    monkeypatch.setattr(job_search, "page_mentions_relocation", lambda url: True)
     assert job_search._keep(job, seen)
     assert job["link"] in seen
 
@@ -42,3 +42,18 @@ def test_fail_without_title_or_relocation(monkeypatch):
     monkeypatch.setattr(job_search, "page_mentions_relocation", lambda url: False)
     assert not job_search._keep(job, seen)
     assert job["link"] not in seen
+
+
+def test_allowed_title_without_relocation(monkeypatch):
+    job = {"link": "http://example.com/job4", "title": "Product Manager"}
+    seen = set()
+    monkeypatch.setattr(job_search, "page_mentions_relocation", lambda url: False)
+    assert not job_search._keep(job, seen)
+    assert job["link"] not in seen
+
+
+def test_query_is_deduped(monkeypatch):
+    job1 = {"link": "http://example.com/job5?utm=123", "title": "Product Manager"}
+    seen = {"http://example.com/job5"}
+    monkeypatch.setattr(job_search, "page_mentions_relocation", lambda url: True)
+    assert not job_search._keep(job1, seen)


### PR DESCRIPTION
## Summary
- narrow search to only Product Manager roles
- dedupe jobs using canonical links
- ensure titles are allowed **and** relocation is mentioned
- send tailored CV files back to Telegram chat
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684534e751888325b3a7d5ff2fdb2271