### PR TITLE
Add Telegram alert on scraping blockage

### DIFF
--- a/job_search_local.py
+++ b/job_search_local.py
@@ -7,6 +7,7 @@ from urllib.parse import quote_plus
 import requests
 from bs4 import BeautifulSoup
 import difflib
+from bot_notify import send_message
 
 HEADERS = {
     "User-Agent": (
@@ -16,6 +17,14 @@ HEADERS = {
     ),
     "Accept-Language": "en-US,en;q=0.9",
 }
+
+
+def notify_blocked(site: str):
+    """Send a Telegram notification when a site blocks access."""
+    try:
+        send_message(f"{site} blocked access")
+    except Exception as exc:  # pragma: no cover - notification failures are non-critical
+        print("WARN: failed to notify Telegram →", exc)
 
 ALLOW_TITLES = [
     "product manager",
@@ -154,6 +163,8 @@ def search_jobs():
                         jobs.append(job)
             except Exception as e:
                 print(f"WARN: {func.__name__} failed for {kw} → {e}")
+                site = func.__name__.replace("scrape_", "").split("_")[0].capitalize()
+                notify_blocked(site)
         time.sleep(1)
     return jobs
 


### PR DESCRIPTION
## Summary
- notify via Telegram when scraping fails
- extend job search to report blocks on Indeed, Otta, and LinkedIn
- ensure local job search reports blocked access too
- test notification path for blocked sites

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68453e1a9ac483259c86f3b4e255b460