### PR TITLE
Add Glassdoor source and new blocked-notification format

### DIFF
--- a/job_search_local.py
+++ b/job_search_local.py
@@ -22,7 +22,7 @@ HEADERS = {
 def notify_blocked(site: str):
     """Send a Telegram notification when a site blocks access."""
     try:
-        send_message(f"{site} blocked access")
+        send_message(f"the request was blocked {site.lower()}")
     except Exception as exc:  # pragma: no cover - notification failures are non-critical
         print("WARN: failed to notify Telegram →", exc)
 

--- a/tests/test_job_search.py
+++ b/tests/test_job_search.py
@@ -69,6 +69,7 @@ def test_blockage_triggers_notification(monkeypatch):
     monkeypatch.setattr(job_search, "scrape_indeed", boom)
     monkeypatch.setattr(job_search, "scrape_otta", lambda kw: [])
     monkeypatch.setattr(job_search, "scrape_linkedin", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_glassdoor", lambda kw: [])
     monkeypatch.setattr(job_search, "scrape_page", lambda kw: [])
     monkeypatch.setattr(job_search, "page_mentions_relocation", lambda url: True)
     monkeypatch.setattr(job_search, "time", types.ModuleType("time"))


### PR DESCRIPTION
## Summary
- include Glassdoor in the main job search
- notify with "the request was blocked" messages
- update tests for the new Glassdoor hook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456489bf348325918619f66ed81d80