### PR TITLE
Add AllJobs RSS scraper

### DIFF
--- a/job_search.py
+++ b/job_search.py
@@ -5,6 +5,7 @@ import re
 import time
 from datetime import date
 from urllib.parse import quote_plus
+import xml.etree.ElementTree as ET
 
 import requests
 from bs4 import BeautifulSoup
@@ -145,10 +146,34 @@ def scrape_glassdoor(keyword: str):
     return rows
 
 
+def scrape_alljobs_rss(keyword: str):
+    """Parse AllJobs RSS feed for a keyword."""
+    url = f"https://www.alljobs.co.il/Rss/?Keywords={quote_plus(keyword)}"
+    r = requests.get(url, headers=HEADERS, timeout=20)
+    r.raise_for_status()
+    root = ET.fromstring(r.text)
+    rows = []
+    for item in root.findall(".//item"):
+        title = item.findtext("title", "")
+        link = item.findtext("link", "")
+        desc = item.findtext("description", "")
+        m = re.search(r"Location[:\s]*([^|<]+)", desc, re.I)
+        loc = m.group(1).strip() if m else "Israel"
+        rows.append({
+            "title": html.unescape(title),
+            "company": "",
+            "location": loc,
+            "link": link,
+            "date": date.today().isoformat(),
+        })
+    return rows
+
+
 SCRAPERS = [
     ("Indeed", "scrape_indeed"),
     ("LinkedIn", "scrape_linkedin"),
     ("Glassdoor", "scrape_glassdoor"),
+    ("AllJobs", "scrape_alljobs_rss"),
 ]
 
 

--- a/tests/test_job_search.py
+++ b/tests/test_job_search.py
@@ -81,9 +81,37 @@ def test_blockage_triggers_notification(monkeypatch):
     monkeypatch.setattr(job_search, "scrape_indeed", boom)
     monkeypatch.setattr(job_search, "scrape_linkedin", lambda kw: [])
     monkeypatch.setattr(job_search, "scrape_glassdoor", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_alljobs_rss", lambda kw: [])
     monkeypatch.setattr(job_search, "time", types.ModuleType("time"))
     job_search.time.sleep = lambda s: None
     monkeypatch.setattr(job_search, "notify_blocked", lambda site: messages.append(site))
 
     job_search.search_jobs()
     assert messages == ["Indeed"]
+
+
+def test_scrapers_include_alljobs():
+    assert any(name == "AllJobs" for name, _ in job_search.SCRAPERS)
+
+
+def test_rss_scraper(monkeypatch):
+    rss = """
+    <rss><channel>
+        <item>
+            <title>Product Manager</title>
+            <link>http://example.com/rss1</link>
+            <description>Location: Tel Aviv, Israel</description>
+        </item>
+    </channel></rss>
+    """
+
+    class Resp:
+        text = rss
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(job_search.requests, "get", lambda url, headers=None, timeout=20: Resp(), raising=False)
+    jobs = job_search.scrape_alljobs_rss("pm")
+    assert jobs[0]["location"] == "Tel Aviv, Israel"
+    assert jobs[0]["link"] == "http://example.com/rss1"


### PR DESCRIPTION
## Summary
- parse jobs from the AllJobs RSS feed with xml
- include the AllJobs scraper in the search pipeline
- test the new scraper and update notification test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d5fe78ef8832593784f3880c3fdb1