### PR TITLE
Add new sources for job search

### DIFF
--- a/tests/test_job_search.py
+++ b/tests/test_job_search.py
@@ -81,6 +81,11 @@ def test_blockage_triggers_notification(monkeypatch):
     monkeypatch.setattr(job_search, "scrape_indeed", boom)
     monkeypatch.setattr(job_search, "scrape_linkedin", lambda kw: [])
     monkeypatch.setattr(job_search, "scrape_glassdoor", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_jobdata_api", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_remotive", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_jobicy", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_iitjobs", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_craigslist", lambda kw: [])
     monkeypatch.setattr(job_search, "time", types.ModuleType("time"))
     job_search.time.sleep = lambda s: None
     monkeypatch.setattr(job_search, "notify_blocked", lambda site: messages.append(site))


### PR DESCRIPTION
## Summary
- scrape job listings from JobdataAPI, Remotive, Jobicy, IITJobs, and Craigslist
- include the new scrapers in the default SCRAPERS list
- update tests to stub the extra scrapers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d63e2361c83258517ebfd1c08550a