### PR TITLE
Improve workflow logging

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -18,10 +18,32 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          pytest -vv | tee pytest.log
+      - uses: actions/upload-artifact@v4
+        with:
+          name: test-logs
+          path: pytest.log
       - name: Run bot
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           GMAIL_USER: ${{ secrets.GMAIL_USER }}
           GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
-        run: python main.py
+        run: python main.py | tee bot.log
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bot-logs
+          path: bot.log
+      - name: Send logs to Telegram
+        if: always()
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          python - <<'PY'
+          from bot_notify import send_document
+          send_document('pytest.log', caption='pytest log')
+          send_document('bot.log', caption='bot log')
+          PY

--- a/job_search.py
+++ b/job_search.py
@@ -280,6 +280,7 @@ def search_jobs(keywords=None, scrapers=None):
     scrapers = scrapers or SCRAPERS
     seen = set()
     jobs = []
+    blocked = set()
     for kw in keywords:
         for site, func_name in scrapers:
             func = globals()[func_name]
@@ -289,7 +290,9 @@ def search_jobs(keywords=None, scrapers=None):
                         jobs.append(job)
             except Exception as exc:
                 print(f"WARN: {func.__name__} failed for {kw} → {exc}")
-                notify_blocked(site)
+                if site not in blocked:
+                    notify_blocked(site)
+                    blocked.add(site)
             time.sleep(1)
     return jobs
 

--- a/tests/test_job_search.py
+++ b/tests/test_job_search.py
@@ -92,3 +92,26 @@ def test_blockage_triggers_notification(monkeypatch):
 
     job_search.search_jobs()
     assert messages == ["Indeed"]
+
+
+def test_blocked_once_for_multiple_keywords(monkeypatch):
+    messages = []
+    monkeypatch.setattr(job_search, "KEYWORDS", ["kw1", "kw2"])
+
+    def boom(keyword):
+        raise Exception("blocked")
+
+    monkeypatch.setattr(job_search, "scrape_indeed", boom)
+    monkeypatch.setattr(job_search, "scrape_linkedin", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_glassdoor", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_jobdata_api", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_remotive", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_jobicy", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_iitjobs", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_craigslist", lambda kw: [])
+    monkeypatch.setattr(job_search, "time", types.ModuleType("time"))
+    job_search.time.sleep = lambda s: None
+    monkeypatch.setattr(job_search, "notify_blocked", lambda site: messages.append(site))
+
+    job_search.search_jobs()
+    assert messages == ["Indeed"]


### PR DESCRIPTION
## Summary
- run pytest in CI to highlight failures
- capture verbose test output and bot output as artifacts for debugging
- send both logs to Telegram at the end of the daily workflow
- notify each provider only once per run when blocked
- test provider notification deduplication

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d65438c1c8325bf33ce937039854f