### PR TITLE
Improve blocked site notifications and add log uploader

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -36,3 +36,8 @@ jobs:
         with:
           name: bot-logs
           path: bot.log
+      - name: Send logs to Telegram
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: python send_logs.py

--- a/job_search.py
+++ b/job_search.py
@@ -280,6 +280,7 @@ def search_jobs(keywords=None, scrapers=None):
     scrapers = scrapers or SCRAPERS
     seen = set()
     jobs = []
+    blocked = set()
     for kw in keywords:
         for site, func_name in scrapers:
             func = globals()[func_name]
@@ -289,7 +290,9 @@ def search_jobs(keywords=None, scrapers=None):
                         jobs.append(job)
             except Exception as exc:
                 print(f"WARN: {func.__name__} failed for {kw} → {exc}")
-                notify_blocked(site)
+                if site not in blocked:
+                    notify_blocked(site)
+                    blocked.add(site)
             time.sleep(1)
     return jobs
 

--- a/send_logs.py
+++ b/send_logs.py
@@ -1,0 +1,19 @@
+import os
+from bot_notify import send_document
+
+
+def main():
+    if os.path.exists('pytest.log'):
+        try:
+            send_document('pytest.log', caption='Test logs')
+        except Exception as exc:
+            print('WARN: failed to send test log →', exc)
+    if os.path.exists('bot.log'):
+        try:
+            send_document('bot.log', caption='Bot logs')
+        except Exception as exc:
+            print('WARN: failed to send bot log →', exc)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_job_search.py
+++ b/tests/test_job_search.py
@@ -92,3 +92,26 @@ def test_blockage_triggers_notification(monkeypatch):
 
     job_search.search_jobs()
     assert messages == ["Indeed"]
+
+
+def test_notify_blocked_once_per_provider(monkeypatch):
+    messages = []
+    monkeypatch.setattr(job_search, "KEYWORDS", ["kw1", "kw2"])
+
+    def boom(keyword):
+        raise Exception("blocked")
+
+    monkeypatch.setattr(job_search, "scrape_indeed", boom)
+    monkeypatch.setattr(job_search, "scrape_linkedin", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_glassdoor", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_jobdata_api", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_remotive", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_jobicy", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_iitjobs", lambda kw: [])
+    monkeypatch.setattr(job_search, "scrape_craigslist", lambda kw: [])
+    monkeypatch.setattr(job_search, "time", types.ModuleType("time"))
+    job_search.time.sleep = lambda s: None
+    monkeypatch.setattr(job_search, "notify_blocked", lambda site: messages.append(site))
+
+    job_search.search_jobs()
+    assert messages == ["Indeed"]


### PR DESCRIPTION
## Summary
- avoid duplicate provider notifications in `search_jobs`
- test that blocked notices only send once per provider
- send workflow logs to Telegram via new helper script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d6ac1c4648325a05c7795d28f200b